### PR TITLE
Dynamic frequencies

### DIFF
--- a/contracts/Payroll/Payroll.sol
+++ b/contracts/Payroll/Payroll.sol
@@ -13,8 +13,8 @@ contract Payroll is IPayroll, Ownable {
 	IEmployeeStorage public employeeStorage;
 	IExchange public exchange;
 
-	uint constant public allocationFrequency = 180 days; // 6 months
-	uint constant public paydayFrequency = 30 days; // 1 month
+	uint public allocationFrequency;
+	uint public paydayFrequency;
 
 	// Modifiers
 
@@ -30,9 +30,11 @@ contract Payroll is IPayroll, Ownable {
 
 	// Init/setters
 
-	function Payroll(address _exchange) {
+	function Payroll(address _exchange, uint _allocationFrequency, uint _paydayFrequency) {
 		setEmployeeStorage(new EmployeeStorage());
 		setExchange(_exchange);
+		allocationFrequency = _allocationFrequency > 0 ? _allocationFrequency : 180 days; // defaults to 6 months
+		paydayFrequency = _paydayFrequency > 0 ? _paydayFrequency : 30 days; // defaults to 1 month
 	}
 
 	function setEmployeeStorage(address _newEmployeeStorage) onlyOwner validAddress(_newEmployeeStorage) {

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -4,8 +4,8 @@ module.exports = (deployer, network) => {
 	const USDExchange = artifacts.require('USDExchange.sol')
 	const Payroll = artifacts.require('Payroll.sol')
 
-	const allocationFrequency = network == 'live' ? 0 : 60; // default for mainnet, 60 seconds for testnets
-	const paydayFrequency = network == 'live' ? 0 : 60; // default for mainnet, 60 seconds for testnets
+	const allocationFrequency = network == 'live' ? 0 : 60 // default for mainnet, 60 seconds for testnets
+	const paydayFrequency = network == 'live' ? 0 : 60 // default for mainnet, 60 seconds for testnets
 
 	deployer.deploy(USDExchange, web3.eth.coinbase).then(() => {
 		return deployer.deploy(Payroll, USDExchange.address, allocationFrequency, paydayFrequency)

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -4,7 +4,10 @@ module.exports = (deployer, network) => {
 	const USDExchange = artifacts.require('USDExchange.sol')
 	const Payroll = artifacts.require('Payroll.sol')
 
+	const allocationFrequency = network == 'live' ? 0 : 60; // default for mainnet, 60 seconds for testnets
+	const paydayFrequency = network == 'live' ? 0 : 60; // default for mainnet, 60 seconds for testnets
+
 	deployer.deploy(USDExchange, web3.eth.coinbase).then(() => {
-		return deployer.deploy(Payroll, USDExchange.address)
+		return deployer.deploy(Payroll, USDExchange.address, allocationFrequency, paydayFrequency)
 	})
 }

--- a/test/PayrollTests.js
+++ b/test/PayrollTests.js
@@ -52,7 +52,7 @@ contract('Payroll', accounts => {
 		tokenD = await ERC20Token.new(10000e4, 'Test Token D', 4, 'TTD')
 		employeeStorage = await EmployeeStorage.new()
 		exchange = await USDExchange.new(oracleAddress)
-		payroll = await Payroll.new(exchange.address)
+		payroll = await Payroll.new(exchange.address, 0, 0)
 		await employeeStorage.transferOwnership(payroll.address)
 		await payroll.setEmployeeStorage(employeeStorage.address)
 	})


### PR DESCRIPTION
Helps test consecutive allocations and paydays on testnets by reducing their allowed frequency.